### PR TITLE
Make order workflow visible

### DIFF
--- a/src/pages/DeliveryDashboard.js
+++ b/src/pages/DeliveryDashboard.js
@@ -117,7 +117,8 @@ export default function DeliveryDashboard() {
 						list = (all || []).filter(o => ['pending','confirmed','preparing'].includes(o.status));
 					} catch (_) {}
 				}
-				if (mounted) setAvailableOrders((list || []).filter(o => o.status === 'ready_for_pickup'));
+				// Show all assignable orders; backend already limits to pending/confirmed/preparing
+				if (mounted) setAvailableOrders(list || []);
 			} catch (e) {
 				if (mounted) setAvailableOrders([]);
 			}


### PR DESCRIPTION
Remove client-side filter for 'ready_for_pickup' status in DeliveryDashboard to show all assignable orders.

Previously, the dashboard only displayed orders with 'ready_for_pickup' status, causing newly paid 'pending' orders to be invisible. This change ensures all orders returned by the API (which are already filtered to assignable statuses like pending, confirmed, preparing) are displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5191f09-b769-4539-9e8d-a5727e08cc17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5191f09-b769-4539-9e8d-a5727e08cc17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

